### PR TITLE
fix: repair failing git benchmarks

### DIFF
--- a/internal/git/git_bench_test.go
+++ b/internal/git/git_bench_test.go
@@ -145,7 +145,8 @@ func BenchmarkInstaller_InstallHook(b *testing.B) {
 	}
 
 	sharedDir := filepath.Join(tmpDir, "pre-commit")
-	if err := os.MkdirAll(sharedDir, 0o750); err != nil {
+	err = os.MkdirAll(sharedDir, 0o750)
+	if err != nil {
 		b.Fatal(err)
 	}
 
@@ -179,7 +180,8 @@ func BenchmarkInstaller_IsHookInstalled(b *testing.B) {
 	}
 
 	sharedDir := filepath.Join(tmpDir, "pre-commit")
-	if err := os.MkdirAll(sharedDir, 0o750); err != nil {
+	err = os.MkdirAll(sharedDir, 0o750)
+	if err != nil {
 		b.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
- use README for repository content benchmark
- create a shared directory for installer benchmarks

## Testing
- `go test -run ^$ -bench . ./internal/git`
- `go test ./...` *(fails: TestCopyDir, TestEOFCheckRunErrorCases, TestWhitespaceCheckRunErrorCases)*

**Assignees:** mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68b1a8356e188321823b57848a703625