### PR TITLE
fix: stabilize benchmarking setup

### DIFF
--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -336,7 +336,9 @@ func BenchmarkPreCommitSystem_IndividualChecks(b *testing.B) {
 func setupTestRepo(b *testing.B) string {
 	tmpDir := b.TempDir()
 
-	cmd := exec.Command("git", "init")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
## Summary
- ensure hook installation benchmarks create required temp directories
- initialize temporary git repos and use default check constructors in benchmarks
- ignore expected errors during individual check benchmarks

## Testing
- `go test -run=none -bench=BenchmarkPreCommitSystem_ -count=1 ./internal`
- `go test ./internal/...` *(fails: "EOF issues found" does not contain "failed to write file")*

/assign @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68b1b39672a883219a2a1a63e816806a