### PR TITLE
[Tests] Ensure benchmarks use writable devnull

### DIFF
--- a/cmd/go-pre-commit/main_test.go
+++ b/cmd/go-pre-commit/main_test.go
@@ -470,7 +470,10 @@ func BenchmarkMain(b *testing.B) {
 	}()
 
 	// Discard output during benchmark
-	devNull, _ := os.Open(os.DevNull)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		b.Fatalf("failed to open devnull: %v", err)
+	}
 	os.Stdout = devNull
 	os.Stderr = devNull
 	defer func() {
@@ -479,8 +482,8 @@ func BenchmarkMain(b *testing.B) {
 		}
 	}()
 
-	// Set args for list command (fast operation)
-	os.Args = []string{"go-pre-commit", "list"}
+	// Use help command for fast execution
+	os.Args = []string{"go-pre-commit", "--help"}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/cmd/production-validation/main_test.go
+++ b/cmd/production-validation/main_test.go
@@ -435,7 +435,16 @@ func BenchmarkMain(b *testing.B) {
 	}()
 
 	// Discard output
-	os.Stdout, _ = os.Open(os.DevNull)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		b.Fatalf("failed to open devnull: %v", err)
+	}
+	os.Stdout = devNull
+	defer func() {
+		if err := devNull.Close(); err != nil {
+			b.Logf("failed to close devnull: %v", err)
+		}
+	}()
 
 	// Mock fast validator
 	testDeps := getDependencies()


### PR DESCRIPTION
## What Changed
- Opened `/dev/null` with write permissions in production-validation benchmark to avoid bad file descriptor errors
- Updated go-pre-commit benchmark to open `/dev/null` for writing and replaced the invalid `list` command with `--help`

## Why It Was Necessary
- Benchmarks were failing or logging errors because they attempted to write to read-only `/dev/null` and invoked a non-existent command

## Testing Performed
- `go test -run '^$' -bench BenchmarkMain ./cmd/production-validation`
- `go test -run '^$' -bench BenchmarkMain ./cmd/go-pre-commit`
- `go test ./cmd/go-pre-commit/cmd ./cmd/production-validation` *(fails: tests expect a git repository and full environment)*

## Impact / Risk
- Low: changes are confined to benchmark tests and do not affect production code

/assign @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68b1ba66ad0c8321a068186fc9b8d3c9